### PR TITLE
Implement page-action api

### DIFF
--- a/src/page-action.ts
+++ b/src/page-action.ts
@@ -1,0 +1,9 @@
+export interface PageAction<T> {
+  (bubbleFn: () => T): Promise<T>;
+}
+
+export interface ActionsHash {
+  [key: string]: PageAction<any>;
+}
+
+export type AvailableActions = Array<PageAction<any>>;

--- a/src/page-action.ts
+++ b/src/page-action.ts
@@ -5,5 +5,3 @@ export interface PageAction<T> {
 export interface ActionsHash {
   [key: string]: PageAction<any>;
 }
-
-export type AvailableActions = Array<PageAction<any>>;

--- a/src/page-object.ts
+++ b/src/page-object.ts
@@ -1,19 +1,17 @@
 import { Client } from 'webdriverio';
-import { ActionsHash, PageAction, AvailableActions } from './page-action';
+import { ActionsHash, PageAction } from './page-action';
 
 export interface DriverAPI {
   browser: Client<any>;
 }
 
-export class Widget {
-  static get scope(): string {
-    return '';
-  }
+export interface WidgetAPI {
+  scope: string;
+  actions: ActionsHash;
+  availableActions(): Promise<ActionsHash>;
+}
 
-  static get actions(): ActionsHash {
-    return {};
-  }
-
+export class Widget implements WidgetAPI {
   driverAPI: DriverAPI;
   parentScope: string;
 
@@ -23,14 +21,18 @@ export class Widget {
   }
 
   get scope(): string {
-    return this.constructor.scope;
+    return '';
+  }
+
+  get actions(): ActionsHash {
+    return {};
   }
 
   get browser(): Client<any> {
     return this.driverAPI.browser;
   }
 
-  async availableActions(): Promise<AvailableActions> {
-    return [];
+  async availableActions(): Promise<ActionsHash> {
+    return this.actions;
   }
 }

--- a/src/page-object.ts
+++ b/src/page-object.ts
@@ -1,4 +1,5 @@
 import { Client } from 'webdriverio';
+import { ActionsHash, PageAction, AvailableActions } from './page-action';
 
 export interface DriverAPI {
   browser: Client<any>;
@@ -9,8 +10,12 @@ export class Widget {
     return '';
   }
 
-  driverAPI: DriverAPI
-  parentScope: string
+  static get actions(): ActionsHash {
+    return {};
+  }
+
+  driverAPI: DriverAPI;
+  parentScope: string;
 
   constructor(driverAPI: DriverAPI, parentScope: string = '') {
     this.driverAPI = driverAPI;
@@ -23,5 +28,9 @@ export class Widget {
 
   get browser(): Client<any> {
     return this.driverAPI.browser;
+  }
+
+  async availableActions(): Promise<AvailableActions> {
+    return [];
   }
 }

--- a/test/absolute-selector.test.js
+++ b/test/absolute-selector.test.js
@@ -3,7 +3,7 @@ import { Widget } from '../src/page-object';
 import component from '../src/component';
 
 class Page extends Widget {
-  static get scope() {
+  get scope() {
     return '.grand-parent';
   }
 
@@ -11,7 +11,7 @@ class Page extends Widget {
     return component(
       this,
       class extends Widget {
-        static get scope() {
+        get scope() {
           return '.my-widget';
         }
 
@@ -19,7 +19,7 @@ class Page extends Widget {
           return component(
             this,
             class extends Widget {
-              static get scope() {
+              get scope() {
                 return '.child-widget';
               }
             }

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -4,7 +4,7 @@ import component from '../src/component';
 import absoluteSelector from '../src/absolute-selector';
 
 class Page extends Widget {
-  static get scope() {
+  get scope() {
     return '.home-page';
   }
 
@@ -22,7 +22,7 @@ class Page extends Widget {
                 return component(
                   this,
                   class extends Widget {
-                    static get scope() {
+                    get scope() {
                       return '.tile';
                     }
                   }

--- a/test/fixtures/driver-api.ts
+++ b/test/fixtures/driver-api.ts
@@ -1,0 +1,25 @@
+import { Client } from 'webdriverio';
+import { DriverAPI } from '../../src/page-object';
+import { waitMS } from '../../src/waiters';
+
+class Router {
+  routeName: string;
+
+  constructor() {
+    this.routeName = 'home';
+  }
+
+  async go(routeName) {
+    await waitMS(5);
+    return (this.routeName = routeName);
+  }
+}
+
+export class FakeDriver implements DriverAPI {
+  browser: Client<any>
+  router: Router
+
+  constructor() {
+    this.router = new Router();
+  }
+}

--- a/test/fixtures/page-action.ts
+++ b/test/fixtures/page-action.ts
@@ -1,0 +1,127 @@
+import { Widget } from '../../src/page-object';
+import component from '../../src/component';
+import absoluteSelector from '../../src/absolute-selector';
+import { waitMS } from '../../src/waiters';
+import { ActionsHash } from '../../src/page-action';
+
+class Router {
+  routeName: string;
+
+  constructor() {
+    this.routeName = 'home';
+  }
+
+  async go(routeName) {
+    await waitMS(5)
+    return this.routeName = routeName;
+  }
+}
+
+function captureActions(ctx: Widget): ActionsHash {
+  let captured = {};
+  for(let key in Object.keys(ctx.actions)) {
+    const action = ctx.actions[key];
+    captured[key] = action.bind(ctx);
+  }
+  return captured;
+}
+
+class App extends Widget {
+  get actions() {
+    return {
+      async goHome() {
+        await this.driverAPI.browser.url('home');
+        return this.homePage;
+      },
+
+      async goProduct() {
+        await this.driverAPI.browser.url('product');
+        return this.productPage;
+      }
+    }
+  }
+
+  get homePage() {
+    const { goProduct } = captureActions(this);
+    return component(this, class extends HomePage {
+      get actions() {
+        return { clickBanner: goProduct };
+      }
+    });
+  }
+
+  get productPage() {
+    const { goHome } = captureActions(this);
+    return component(this, class extends ProductPage {
+      get actions() {
+        return { clickBack: goHome };
+      }
+    });
+  }
+}
+
+class Banner extends Widget {
+  async click(exit) {
+    return exit();
+  }
+
+  async availableActions() {
+    const { onClick } = captureActions(this);
+
+    return {
+      clickBanner: () => this.click(onClick)
+    };
+  }
+}
+
+class Detail extends Widget {
+  async clickBack(exit) {
+    return exit();
+  }
+
+  async availableActions() {
+    const { onClick } = captureActions(this);
+
+    return {
+      clickBack: () => this.clickBack(onClick)
+    };
+  }
+}
+class ProductPage extends Widget {
+  static get scope() {
+    return '.product-page';
+  }
+
+  get isActive() {
+    return this.driverAPI.router.routeName === 'product';
+  }
+
+  get detail() {
+    const { clickBack } = captureActions(this);
+
+    return component(this, class extends Detail {
+      get actions() {
+        return { onClick: clickBack };
+      }
+    });
+  }
+}
+class HomePage extends Widget {
+  static get scope() {
+    return '.home-page';
+  }
+
+  get isActive() {
+    return this.driverAPI.router.routeName === 'home';
+  }
+
+  get banner() {
+    const { clickBanner } = captureActions(this);
+
+    return component(this, class extends Banner {
+      get actions() {
+        return { onClick: clickBanner }
+      }
+    });
+  }
+}

--- a/test/page-action.test.js
+++ b/test/page-action.test.js
@@ -1,0 +1,34 @@
+import { Widget } from '../src/page-object';
+import component from '../src/component';
+import absoluteSelector from '../src/absolute-selector';
+
+class Page extends Widget {
+  static get scope() {
+    return '.home-page';
+  }
+
+  static get actions() {
+    const quitPage = ::this.quitPage;
+    return { quitPage };
+  }
+
+  private async quitPage() {
+    return 'successfully quit';
+  }
+
+  get banner() {
+    return component(this, class extends Widget {
+      async unfocus(exit) {
+        return exit();
+      }
+
+      async availableActions() {
+        const { quitBanner } = this.constructor.actions;
+
+        return [
+          () => this.unfocus(quitBanner);
+        ];
+      }
+    });
+  }
+}

--- a/test/page-action.test.js
+++ b/test/page-action.test.js
@@ -1,33 +1,116 @@
 import { Widget } from '../src/page-object';
 import component from '../src/component';
 import absoluteSelector from '../src/absolute-selector';
+import { waitMS } from '../src/waiters';
 
-class Page extends Widget {
+class Router {
+  constructor() {
+    this.routeName = 'home';
+  }
+
+  async go(routeName) {
+    await waitMS(5)
+    return this.routeName = routeName;
+  }
+}
+
+class App extends Widget {
+  get actions() {
+    const goHome = ::this.goHome;
+    const goProduct = ::this.goProduct;
+    return { goHome, goProduct };
+  }
+
+  get homePage() {
+    const { goProduct } = this.actions;
+    return component(this, class extends HomePage {
+      get actions() {
+        return { clickBanner: goProduct };
+      }
+    });
+  }
+
+  get productPage() {
+    const { goHome } = this.actions;
+    return component(this, class extends ProductPage {
+      get actions() {
+        return { clickBack: goHome };
+      }
+    });
+  }
+
+  private async goHome() {
+    await this.driverAPI.app.go('home');
+    return this.homePage;
+  }
+
+  private async goProduct() {
+    await this.driverAPI.app.go('product');
+    return this.productPage;
+  }
+}
+
+class Banner extends Widget {
+  async click(exit) {
+    return exit();
+  }
+
+  async availableActions() {
+    const { onClick } = this.constructor.actions;
+
+    return {
+      clickBanner: () => this.click(onClick)
+    };
+  }
+}
+
+class Detail extends Widget {
+  async clickBack(exit) {
+    return exit();
+  }
+
+  async availableActions() {
+    const { onClick } = this.actions;
+
+    return {
+      clickBack: () => this.clickBack(onClick)
+    };
+  }
+}
+class ProductPage extends Widget {
+  static get scope() {
+    return '.product-page';
+  }
+
+  get isActive() {
+    return this.driverAPI.router.routeName === 'product';
+  }
+
+  get detail() {
+    const { clickBack } = this.actions;
+
+    return component(this, class extends Detail {
+      get actions() {
+        return { onClick: clickBack };
+      }
+    });
+  }
+}
+class HomePage extends Widget {
   static get scope() {
     return '.home-page';
   }
 
-  static get actions() {
-    const quitPage = ::this.quitPage;
-    return { quitPage };
-  }
-
-  private async quitPage() {
-    return 'successfully quit';
+  get isActive() {
+    return this.driverAPI.router.routeName === 'home';
   }
 
   get banner() {
-    return component(this, class extends Widget {
-      async unfocus(exit) {
-        return exit();
-      }
+    const { clickBanner } = this.actions;
 
-      async availableActions() {
-        const { quitBanner } = this.constructor.actions;
-
-        return [
-          () => this.unfocus(quitBanner);
-        ];
+    return component(this, class extends Banner {
+      get actions() {
+        return { onClick: clickBanner }
       }
     });
   }


### PR DESCRIPTION
# Background

One of the most desired functionalities of modern day webdriver integration testing is the ability to perma-crawl a web-page. The page-object api should therefore expose some programmatic way for actions to chain into other actions and facilitate crawling.

# Changes

move in page-action api and start writing the tests

# Reference

https://www.pivotaltracker.com/n/projects/2132823
  